### PR TITLE
Fall back to repo env variable for scheduled events

### DIFF
--- a/dist/source.js
+++ b/dist/source.js
@@ -16,7 +16,7 @@ function buildSourceMetadata(source, context) {
     const event = context.payload;
     const {
       pull_request: { head, number, title } = {},
-      repository: { full_name }
+      repository: { full_name = process.env.GITHUB_REPOSITORY } = {}
     } = event;
     const sha = head ? head.sha : context.sha;
     const ref = head ? head.ref : context.ref;

--- a/source.js
+++ b/source.js
@@ -19,7 +19,7 @@ function buildSourceMetadata(source, context) {
 
     const {
       pull_request: { head, number, title } = {},
-      repository: { full_name },
+      repository: { full_name = process.env.GITHUB_REPOSITORY } = {},
     } = event;
     const sha = head ? head.sha : context.sha;
     const ref = head ? head.ref : context.ref;


### PR DESCRIPTION
The `schedule` event has nearly no payload but the environment variables are still set so fall back to those to get the repo full name