### PR TITLE
Filter and report on crash uploads

### DIFF
--- a/dist/upload.js
+++ b/dist/upload.js
@@ -2735,8 +2735,8 @@ var require_jsonata = __commonJS({
                 var c = typeof require == "function" && require;
                 if (!f && c)
                   return c(i2, true);
-                if (u)
-                  return u(i2, true);
+                if (u2)
+                  return u2(i2, true);
                 var a = new Error("Cannot find module '" + i2 + "'");
                 throw a.code = "MODULE_NOT_FOUND", a;
               }
@@ -2748,7 +2748,7 @@ var require_jsonata = __commonJS({
             }
             return n[i2].exports;
           }
-          for (var u = typeof require == "function" && require, i = 0; i < t.length; i++)
+          for (var u2 = typeof require == "function" && require, i = 0; i < t.length; i++)
             o(t[i]);
           return o;
         }
@@ -8467,8 +8467,9 @@ async function makeReplaysPublic(apiKey, recordings) {
 async function uploadRecordings({ cli, apiKey, filter, public: public2 = false, metadata }) {
   try {
     const recordingIds = await upload(cli, filter, metadata);
-    const uploaded = cli.listAllRecordings().filter((u) => u.status === "uploaded" && recordingIds.includes(u.recordingId));
-    const crashed = cli.listAllRecordings().filter((u) => u.status === "crashUploaded" && recordingIds.includes(u.recordingId));
+    const recordings = cli.listAllRecordings().filter(u = recordingIds.includes(u.recordingId));
+    const uploaded = recordings.filter((u2) => u2.status === "uploaded");
+    const crashed = recordings.filter((u2) => u2.status === "crashUploaded");
     console.log("Uploaded", recordingIds.length, "replay(s)");
     console.log("Uploaded", crashed.length, "crash report(s)");
     if (public2 && recordingIds.length > 0) {

--- a/dist/upload.js
+++ b/dist/upload.js
@@ -8467,8 +8467,10 @@ async function makeReplaysPublic(apiKey, recordings) {
 async function uploadRecordings({ cli, apiKey, filter, public: public2 = false, metadata }) {
   try {
     const recordingIds = await upload(cli, filter, metadata);
-    const uploaded = cli.listAllRecordings().filter((u) => recordingIds.includes(u.recordingId));
-    console.log("Uploaded", recordingIds.length, "replays");
+    const uploaded = cli.listAllRecordings().filter((u) => u.status === "uploaded" && recordingIds.includes(u.recordingId));
+    const crashed = cli.listAllRecordings().filter((u) => u.status === "crashUploaded" && recordingIds.includes(u.recordingId));
+    console.log("Uploaded", recordingIds.length, "replay(s)");
+    console.log("Uploaded", crashed.length, "crash report(s)");
     if (public2 && recordingIds.length > 0) {
       const updated = await makeReplaysPublic(apiKey, uploaded);
       console.log("Marked", updated.length, "replays public");

--- a/upload.js
+++ b/upload.js
@@ -90,9 +90,11 @@ async function makeReplaysPublic(apiKey, recordings) {
 async function uploadRecordings({ cli, apiKey, filter, public = false, metadata }) {
   try {
     const recordingIds = await upload(cli, filter, metadata);
-    const uploaded = cli.listAllRecordings().filter(u => recordingIds.includes(u.recordingId));
+    const uploaded = cli.listAllRecordings().filter(u => u.status === "uploaded" && recordingIds.includes(u.recordingId));
+    const crashed = cli.listAllRecordings().filter(u => u.status === "crashUploaded" && recordingIds.includes(u.recordingId));
 
-    console.log("Uploaded", recordingIds.length, "replays");
+    console.log("Uploaded", recordingIds.length, "replay(s)");
+    console.log("Uploaded", crashed.length, "crash report(s)");
 
     if (public && recordingIds.length > 0) {
       const updated = await makeReplaysPublic(apiKey, uploaded);

--- a/upload.js
+++ b/upload.js
@@ -90,8 +90,9 @@ async function makeReplaysPublic(apiKey, recordings) {
 async function uploadRecordings({ cli, apiKey, filter, public = false, metadata }) {
   try {
     const recordingIds = await upload(cli, filter, metadata);
-    const uploaded = cli.listAllRecordings().filter(u => u.status === "uploaded" && recordingIds.includes(u.recordingId));
-    const crashed = cli.listAllRecordings().filter(u => u.status === "crashUploaded" && recordingIds.includes(u.recordingId));
+    const recordings = cli.listAllRecordings().filter(u = recordingIds.includes(u.recordingId));
+    const uploaded = recordings.filter(u => u.status === "uploaded");
+    const crashed = recordings.filter(u => u.status === "crashUploaded");
 
     console.log("Uploaded", recordingIds.length, "replay(s)");
     console.log("Uploaded", crashed.length, "crash report(s)");


### PR DESCRIPTION
## Issue

The "Uploaded" count was only matching against the expected recording id and not the status of the upload so we were reporting all the recordings as uploaded when some might have been crashes

## Resolution

* Filter the uploaded count by status
* Add a message to report on the crash upload as well