### PR TITLE
Ensure that jsonata's filter method returns an array

### DIFF
--- a/dist/upload.js
+++ b/dist/upload.js
@@ -8402,7 +8402,7 @@ async function upload(cli, filter, metadata) {
   const allRecordings = cli.listAllRecordings();
   let recordings = allRecordings;
   if (filter) {
-    const exp = jsonata(`$filter($, ${filter})`);
+    const exp = jsonata(`$filter($, ${filter})[]`);
     recordings = exp.evaluate(allRecordings) || [];
   }
   console.log("Processing", recordings.length, "of", allRecordings.length, "total recordings");

--- a/upload.js
+++ b/upload.js
@@ -6,7 +6,7 @@ async function upload(cli, filter, metadata) {
 
   let recordings = allRecordings;
   if (filter) {
-    const exp = jsonata(`$filter($, ${filter})`);
+    const exp = jsonata(`$filter($, ${filter})[]`);
     recordings = exp.evaluate(allRecordings) || [];
   }
 


### PR DESCRIPTION
## Issue

When the filter function only matches one element, jsonata returns that element instead of that element within an array.

see https://github.com/jsonata-js/jsonata/issues/218#issuecomment-391981518

## Resolution

Append `[]` to the filter function to coerce into an array