### PR TITLE
Reduce logging noise from replay package installs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: "Install Replay CLI"
-      run: npm i --prefix $GITHUB_ACTION_PATH @replayio/replay@${{ inputs.cli-version }}
+      run: npm i --silent --prefix $GITHUB_ACTION_PATH @replayio/replay@${{ inputs.cli-version }}
       shell: sh
     - name: "Upload Recordings"
       id: "upload-recordings"


### PR DESCRIPTION
Suppresses warnings (e.g. for optional dependencies or complaints from older npm versions) when installing the CLI